### PR TITLE
Fix Exercise 7.1 unlock to require Double Deduction Theorem

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -362,7 +362,7 @@ Here are some other interactive logic demonstrations:
         </ol>
 </div>
 
-<div class="exercise" id="EXERCISE-7.1" data-unlocked-by="6.1(a)" data-unlocks="Push PushAlt">
+<div class="exercise" id="EXERCISE-7.1" data-unlocked-by="6.2" data-unlocks="Push PushAlt">
         <div class="name"></div>
         <div class="notes">
             <UL>


### PR DESCRIPTION
Fixes #39

## Bug
Exercise 7.1 unlocks after 6.1(a), but its canonical proof uses the Double Deduction Theorem, which is only unlocked by completing Exercise 6.2. Players who skip 6.2 can reach 7.1 without the needed law.

## Root cause
`data-unlocked-by="6.1(a)"` on `EXERCISE-7.1` does not match the proof dependency on the 6.2 theorem.

## Why this fix is correct
Requiring 6.2 ensures Push/PushAlt are introduced only after the double deduction theorem needed to derive them, matching the suggested fix in the issue report.

## Test plan
- [ ] Complete 6.1(a) without 6.2: Exercise 7.1 stays locked
- [ ] Complete 6.2: Exercise 7.1 unlocks and proof steps are available

Made with [Cursor](https://cursor.com)