### PR TITLE
fix: require 6.2 unlock for Exercise 8.4(b)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -474,7 +474,7 @@ Here are some other interactive logic demonstrations:
         </ol>
 </div>
 
-<div class="exercise" id="EXERCISE-8.4(b)" data-unlocked-by="8.1(a)">
+<div class="exercise" id="EXERCISE-8.4(b)" data-unlocked-by="6.2">
         <div class="name"></div>
         <div class="notes">
         </div>


### PR DESCRIPTION
## Summary

Exercise 8.4(b)'s proof uses the double deduction theorem, which is only unlocked by solving 6.2, but the exercise was gated on 8.1(a).

## Root cause

Same unlock/prerequisite mismatch as #39 for 7.1: players can reach the exercise without having DDT available, so the recorded shortest proof is impossible.

## Fix

Set `data-unlocked-by="6.2"`.