### PR TITLE
fix: align displayed version with HISTORY.md (2.10.7)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@
 
 <p></p>
 <H4 id="version-header"> This is
-  <a href="https://github.com/teorth/QED/blob/master/HISTORY.md">version 2.10.8</a>.
+  <a href="https://github.com/teorth/QED/blob/master/HISTORY.md">version 2.10.7</a>.
 </H4>
 
 If the text has updated to a new version since your last session, you may need to reset the text in order for it to work correctly, or at least redo some of the exercises that unlock certain laws.  This page works best when viewed on a large screen and with the ability to drag-and-drop; in particular, this page is unlikely to be all that functional on a cell phone.  Also one may need a recently updated browser in order for the page to work properly (in particular, grid layouts and local storage should be supported for the best experience).


### PR DESCRIPTION
## Summary

The page header linked to `HISTORY.md` but showed version 2.10.8 while the latest entry in that file is 2.10.7 (Jan 2025).

## Root cause

Commit `3316fec` added the 2.10.7 history entry but bumped the displayed version to 2.10.8 instead.

## Fix

Set the version header back to 2.10.7 to match `HISTORY.md`.

Fixes #35 (same class of version display mismatch).

## Test plan

- [ ] Open `docs/index.html` and confirm the version header reads 2.10.7
- [ ] Confirm `HISTORY.md` top entry is Version 2.10.7


Made with [Cursor](https://cursor.com)